### PR TITLE
fix: delete only user's goal

### DIFF
--- a/src/goals/goals.controller.ts
+++ b/src/goals/goals.controller.ts
@@ -29,6 +29,6 @@ export class GoalsController {
 
   @Delete(':id')
   async delete(@Req() request, @Param('id') id) {
-    this.goalsService.delete(id);
+    this.goalsService.delete(id, request.userId);
   }
 }

--- a/src/goals/goals.service.ts
+++ b/src/goals/goals.service.ts
@@ -28,8 +28,8 @@ export class GoalsService {
     );
   }
 
-  delete(id: any): void {
+  delete(id: number, userId: number): void {
     this.entityManager.query(`DELETE FROM
-    goal WHERE id = ${id}`);
+    goal WHERE id = ${id} AND userId = ${userId}`);
   }
 }


### PR DESCRIPTION
# 1: Controle de acesso quebrado

Se você acompanhou o post sobre o [OWASP Top 10](https://renanzulian.com/posts/owasp-top-10/), aprendeu sobre as principais vulnerabilidades de sistemas WEB. Nessa PR iremos corrigir um exemplo clássico de *Broken Access Control*.

*Obs: se você for um pouco mais experiente poderá observar muitas outras vulnerabilidades do projeto, e a proposta é essa mesma. Mostrar em um sistema real os problemas e comentar alguns deles através de PR's com suas devidas correções.*

## Entendendo a vulnerabilidade

Um dos recursos dessa API são as metas (Goals) que o usuário pode manipular. Através desse recurso ele pode cadastrar seus objetivos para o ano, lista-los e deleta-los. 

Por se tratar de um dado confidencial, todas as rotas desse recurso necessita de autenticação (spoiler que há outras vulnerabilidades nesse processo). Porém há um erro na lógica no momento de deletar uma meta.

### Entendendo o problema

Rota:  my-goals-api.localhost:3000/goals/{id da meta}
Header necessário: { Authorization: "Bearer {{token do usuário}}"}

Você pode pensar momentaneamente que somente o identificador da meta e um token para identificar o usuário é suficiente, mas não. A regra foi implementada sem uma verificação se o usuário tem permissão para deletar aquela meta específica, em outras palavras, se o usuário esta deletar uma meta que é dele. Caso o usuário coloque um ID de uma meta que não é dele em tese o sistema permitiria e isso é uma falha séria, pois o usuário esta com um acesso indevido.

### Como corrigir

Como nesse caso estamos trabalhando com ID numerais e incrementais, fica fácil o usuário identificar possível outros ids. Dessa forma ele poderia facilmente randomizar alguns números menor que as da metas dele e seria possível encontrar algum registro e apagar do nosso sistema. Dessa forma poderíamos trabalhar com ID randômicos como o UUID, porém só isso não seria eficaz, pois estaríamos apenas dificultando o processo para um usuário que colocassem ids aleatórios.

A maneira correta nessa caso é identificar o usuário da sessão e apagar somente a meta que esteja relacionado com o usuário.

Procure os arquivos modificados nessa PR veja a solução proposta.



