### PR TITLE
fix: safe goal delete

### DIFF
--- a/src/goals/goals.service.ts
+++ b/src/goals/goals.service.ts
@@ -29,7 +29,12 @@ export class GoalsService {
   }
 
   delete(id: number, userId: number): void {
-    this.entityManager.query(`DELETE FROM
-    goal WHERE id = ${id} AND userId = ${userId}`);
+    this.entityManager
+      .getRepository(GoalEntity)
+      .createQueryBuilder('goal')
+      .innerJoinAndSelect('goal.user', 'user')
+      .where('goal.id = :goalId AND user.id = :userId', { goalId: id, userId })
+      .delete()
+      .execute();
   }
 }


### PR DESCRIPTION
# 2: Falha de criptografia

Nessa segunda PR iremos corrigir a segunda vulnerabilidade mais comuns, de acordo com o ranking da [OWASP Top 10](https://renanzulian.com/posts/owasp-top-10/), chamado de "[Cryptographic Failures](https://owasp.org/Top10/A03_2021-Injection/)"

## Entendendo a vulnerabilidade

Todos os sistemas são compostos te operações que precisam de inputs e geram outputs. Quando um sistema tem alguma vulnerabilidade de injeção, um usuário malicioso pode alterar algum dos inputs de uma determinada operação para executar um procedimento diferente do esperado

Esses procedimentos podem ter varias consequências. Há casos em que pessoas apenas inserem alguns scripts que mostram a vulnerabilidade para todos os usuários daquele site, comprometendo a confiabilidade dos mesmo no sistema. Isso certamente chamará a atenção dos responsáveis para fazer a manutenção do mesmo.

### Entendendo o problema

Na operação de deletar um objetivo não estamos manipulando devidamente o identificador do objetivo. É bem comum que na camada do banco de dados, se faça queries sem a devida sanitização dos valores antes de realizar o comando. Dessa forma, ao invés de passar um identificador, o usuário poderia simplesmente colocar um valor como " OR 1=1;" que ele iria alterar todo o comando SQL. Nesse caso poderia apagar todos os objetivos listados no banco. 

### Como corrigir

Hoje a maioria dos SDKs para banco de dados já fornecem uma maneira de fazer a sanitização dos inputs. Dessa forma se apenas utilizar a API corretamente podemos estar seguros. Esse foi exatamente o caso, deixamos de operar com RAW SQL para utilizar as funções que o TypeORM nos fornece.

Além disso, poderíamos fazer uma validação na camada do controller para ter ainda mais segurança.

Procure os arquivos modificados nessa PR veja a solução proposta.



